### PR TITLE
Depend on SwiftSyntax from the swiftlang org

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -32,7 +32,7 @@ let package = Package(
         ),
     ],
     dependencies: [
-        .package(url: "https://github.com/apple/swift-syntax.git", from: "509.0.0"),
+        .package(url: "https://github.com/swiftlang/swift-syntax.git", from: "509.0.0"),
     ],
     targets: [
         .target(


### PR DESCRIPTION
A few packages exporting macros have already migrated to the `SwiftLang` org instead of `Apple`. SwiftPM resolution is relatively broken and apparently picks versions randomly when depending on these packages and Engine, creating a constant churn with Packages.resolved. 
I believe that updating to the SwiftLang org will fix that issue (or at least that the issue will be fixed once all packages have migrated).