### PR TITLE
Fix `_DefaultStyledView` body() crash introduced in 1.9.0

### DIFF
--- a/Sources/Engine/Sources/PrimitiveView.swift
+++ b/Sources/Engine/Sources/PrimitiveView.swift
@@ -5,7 +5,7 @@
 import SwiftUI
 
 @MainActor @preconcurrency
-public protocol PrimitiveView: View where Body == Never {
+public protocol _PrimitiveView: View {
 
     @MainActor @preconcurrency static func makeView(
         view: _GraphValue<Self>,
@@ -23,7 +23,11 @@ public protocol PrimitiveView: View where Body == Never {
     ) -> Int?
 }
 
-extension PrimitiveView where Body == Never {
+@MainActor @preconcurrency
+public protocol PrimitiveView: _PrimitiveView where Body == Never {
+}
+
+extension PrimitiveView {
 
     public var body: Never {
         bodyError()

--- a/Sources/Engine/Sources/ViewAlias.swift
+++ b/Sources/Engine/Sources/ViewAlias.swift
@@ -46,7 +46,7 @@ import SwiftUI
 /// you can implement the optional `defaultBody`.
 ///
 @MainActor @preconcurrency
-public protocol ViewAlias: PrimitiveView where Body == Never {
+public protocol ViewAlias: PrimitiveView {
     associatedtype DefaultBody: View = EmptyView
     @ViewBuilder @MainActor @preconcurrency var defaultBody: DefaultBody { get }
 }

--- a/Sources/EngineMacros/StyledView.swift
+++ b/Sources/EngineMacros/StyledView.swift
@@ -98,7 +98,7 @@ public macro StyledView() = #externalMacro(module: "EngineMacrosCore", type: "St
 /// A protocol intended to be used with the ``@StyledView`` macro define a
 /// ``ViewStyle`` and all it's related components.
 @MainActor @preconcurrency
-public protocol StyledView: PrimitiveView, DynamicProperty {
+public protocol StyledView: _PrimitiveView, DynamicProperty {
     associatedtype _Body: View
     @ViewBuilder @MainActor @preconcurrency var _body: _Body { get }
 }


### PR DESCRIPTION
Great lib! Learned a lot from your implementation.

The improvements in `PrimitiveView` done in 1.9.0 unfortunately broke `StyledView`. They are expected to have valid `Body`, but the new constraint casts it as `Never`, so body falls through to `bodyError()`. The problem is easy to reproduce.

This PR proposes the creation of an underlying `_PrimitiveView` protocol and have both `StyledView` and `PrimitiveView` inherit from that.

```swift
@frozen
public struct _DefaultStyledView<Content: StyledView>: View {

    @usableFromInline
    var content: Content

    @inlinable
    public init(_ content: Content) {
        self.content = content
    }

    public var body: some View {
        content.body // bodyError()
    }
}
```