### PR TITLE
Don't visit section parent/headers and footers that are empty views

### DIFF
--- a/Sources/EngineCore/SectionVisitor.swift
+++ b/Sources/EngineCore/SectionVisitor.swift
@@ -41,31 +41,71 @@ private struct SectionSubviewIterator<
     ) {
         var context = context
         context.traits = []
-        var headerContext = context.union(.header)
-        headerContext.id.append(offset: 0)
-        headerContext.id.append(Parent.self)
-        visitor.value.visit(
-            content: content.parent,
-            context: headerContext,
-            stop: &stop
-        )
+
+        do {
+            var headerContext = context.union(.header)
+            headerContext.id.append(offset: 0)
+            headerContext.id.append(Parent.self)
+
+            var isEmptyVisitor = MultiViewIsEmptyVisitor()
+            content.parent.visit(visitor: &isEmptyVisitor)
+
+            if isEmptyVisitor.isEmpty == false {
+                visitor.value.visit(
+                    content: content.parent,
+                    context: headerContext,
+                    stop: &stop
+                )
+            }
+        }
+
         guard !stop else { return }
-        var contentContext = context
-        contentContext.id.append(offset: 1)
-        contentContext.id.append(Content.self)
-        content.content.visit(
-            visitor: visitor,
-            context: contentContext,
-            stop: &stop
-        )
+
+        do {
+            var contentContext = context
+            contentContext.id.append(offset: 1)
+            contentContext.id.append(Content.self)
+            content.content.visit(
+                visitor: visitor,
+                context: contentContext,
+                stop: &stop
+            )
+        }
+
         guard !stop else { return }
-        var footerContext = context.union(.footer)
-        footerContext.id.append(offset: 2)
-        footerContext.id.append(Footer.self)
-        visitor.value.visit(
-            content: content.footer,
-            context: footerContext,
-            stop: &stop
-        )
+
+        do {
+            var footerContext = context.union(.footer)
+            footerContext.id.append(offset: 2)
+            footerContext.id.append(Footer.self)
+
+            var isEmptyVisitor = MultiViewIsEmptyVisitor()
+            content.footer.visit(visitor: &isEmptyVisitor)
+
+            if isEmptyVisitor.isEmpty == false {
+                visitor.value.visit(
+                    content: content.footer,
+                    context: footerContext,
+                    stop: &stop
+                )
+            }
+        }
+    }
+}
+
+private struct MultiViewIsEmptyVisitor: MultiViewVisitor {
+
+    public private(set) var isEmpty: Bool = true
+
+    @inlinable
+    public init() { }
+
+    public mutating func visit<Content: View>(
+        content: Content,
+        context: Context,
+        stop: inout Bool
+    ) {
+        isEmpty = false
+        stop = true
     }
 }

--- a/Sources/EngineTests/EngineCoreMultiViewVisitorTests.swift
+++ b/Sources/EngineTests/EngineCoreMultiViewVisitorTests.swift
@@ -203,6 +203,21 @@ final class MultiViewVisitorTests: XCTestCase {
                 Text("Footer")
             }
         }
+        expectation(count: 2) {
+            Section {
+                Text("Hello")
+                Text("World")
+            }
+        }
+        expectation(count: 0) {
+            Section {
+                EmptyView()
+            } header: {
+                EmptyView()
+            } footer: {
+                EmptyView()
+            }
+        }
     }
 
     func testForEach() {


### PR DESCRIPTION
This updates `SectionSubviewIterator` to only visit section parent/headers and footers that are not empty views.

Before these changes, these tests would fail.

```swift
// MultiViewVisitorTests
// func testSection()

        expectation(count: 2) { // XCTAssertEqual failed: ("4") is not equal to ("2")
            Section {
                Text("Hello")
                Text("World")
            }
        }
        expectation(count: 0) { // XCTAssertEqual failed: ("2") is not equal to ("0")
            Section {
                EmptyView()
            } header: {
                EmptyView()
            } footer: {
                EmptyView()
            }
        }
```

The private `MultiViewIsEmptyVisitor` was copied from Engine's MultiviewVisitor.swift. Not sure if you'd want to move the public impl to EngineCore or not (or maybe there's a different/better way to check for empty views?)