### PR TITLE
Allow `swift-sytax` 601

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -32,10 +32,7 @@ let package = Package(
         ),
     ],
     dependencies: [
-        .package(
-            url: "https://github.com/swiftlang/swift-syntax",
-            "509.0.0"...(Range<Version>.upToNextMinor(from: "600.0.0").upperBound)
-        ),
+        .package(url: "https://github.com/swiftlang/swift-syntax", "509.0.0"..<"602.0.0"),
     ],
     targets: [
         .target(

--- a/Sources/EngineMacrosCore/StyledViewMacro.swift
+++ b/Sources/EngineMacrosCore/StyledViewMacro.swift
@@ -2,6 +2,7 @@
 // Copyright (c) Nathan Tannar
 //
 
+import Foundation
 import SwiftCompilerPlugin
 import SwiftSyntax
 import SwiftSyntaxBuilder


### PR DESCRIPTION
This PR updates the package's `swift-syntax` requirement to allow version 601, which is the latest stable version, and fixes the associated compiler errors. This should bring the package into alignment with the rest of the ecosystem and prevent it from blocking the use of `swift-syntax` prebuilts. In the future this should be bumped as they tag releases of `swift-syntax` so the latest syntax can be used across a project's dependencies.

Note: there is still a warning, but I'm not familiar enough with macros to fix it immediately.

> Engine/Sources/EngineMacrosCore/StyledViewMacro.swift:11:15 Deprecated default implementation is used to satisfy static method 'expansion(of:providingMembersOf:conformingTo:in:)' required by protocol 'MemberMacro': `MemberMacro` conformance should implement the `expansion` function that takes a `conformingTo` parameter
