### PR TITLE
Expand allowed `swift-syntax` versions for version 6 package

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -32,7 +32,7 @@ let package = Package(
         ),
     ],
     dependencies: [
-        .package(url: "https://github.com/swiftlang/swift-syntax", from: "600.0.0"),
+        .package(url: "https://github.com/swiftlang/swift-syntax", "600.0.0"..<"602.0.0"),
     ],
     targets: [
         .target(


### PR DESCRIPTION
Fixes #37 

Since `swift-syntax` uses major versions to match minor versions of Swift, `from: 600.0.0` is not enough to encompass all possible versions. This PR expands the allowed versions again. Technically I'm not sure about supporting lower versions than the `swift-tools-version`, but `600` seems like a safe minimum since they have to be building with the version 6 compiler to use it in the first place.