### PR TITLE
Fix crash on iOS 17

### DIFF
--- a/Example/Example/ViewStyleExamples.swift
+++ b/Example/Example/ViewStyleExamples.swift
@@ -251,8 +251,8 @@ struct Icon: StyledView {
     var label: Text
     var image: Image
 
-    var body: some View {
-        image.accessibilityLabel(label)
+    static func makeDefaultStyleBody(configuration: IconConfiguration) -> some View {
+        configuration.image.accessibilityLabel(configuration.label)
     }
 }
 
@@ -390,11 +390,11 @@ struct _LabeledView<Label: View, Content: View>: StyledView {
     var label: Label
     var content: Content
 
-    var body: some View {
+    static func makeDefaultStyleBody(configuration: _LabeledViewConfiguration) -> some View {
         HStack {
-            label
+            configuration.label
 
-            content
+            configuration.content
         }
     }
 }

--- a/Sources/Engine/Sources/AnchoredPoint.swift
+++ b/Sources/Engine/Sources/AnchoredPoint.swift
@@ -10,6 +10,7 @@ public struct AnchoredPoint: Hashable, Sendable, Animatable {
     public var anchor: UnitPoint
     public var offset: CGPoint
 
+    @inlinable
     public var animatableData: AnimatablePair<UnitPoint.AnimatableData, CGPoint.AnimatableData> {
         get {
             AnimatablePair(
@@ -32,6 +33,7 @@ public struct AnchoredPoint: Hashable, Sendable, Animatable {
         self.offset = offset
     }
 
+    @inlinable
     public func point(in size: CGSize) -> CGPoint {
         anchor.point(in: size, offset: offset)
     }

--- a/Sources/Engine/Sources/ConditionalView.swift
+++ b/Sources/Engine/Sources/ConditionalView.swift
@@ -8,11 +8,12 @@ import SwiftUI
 public typealias ConditionalView<TrueContent: View, FalseContent: View> = ConditionalContent<TrueContent, FalseContent>
 
 extension ConditionalView: View where TrueContent: View, FalseContent: View {
+
     @inlinable
     public init(
         if condition: Bool,
-        @ViewBuilder then: () -> TrueContent,
-        @ViewBuilder otherwise: () -> FalseContent
+        @ViewBuilder then: () -> TrueContent = { EmptyView() },
+        @ViewBuilder otherwise: () -> FalseContent = { EmptyView() }
     ) {
         self.storage = condition ? .trueContent(then()) : .falseContent(otherwise())
     }
@@ -24,16 +25,6 @@ extension ConditionalView: View where TrueContent: View, FalseContent: View {
         case .falseContent(let falseContent):
             falseContent
         }
-    }
-}
-
-extension ConditionalView where TrueContent: View, FalseContent == EmptyView {
-    @inlinable
-    public init(
-        if condition: Bool,
-        @ViewBuilder then: () -> TrueContent
-    ) {
-        self.init(if: condition, then: then, otherwise: { EmptyView() })
     }
 }
 

--- a/Sources/Engine/Sources/EdgeInsets+Extensions.swift
+++ b/Sources/Engine/Sources/EdgeInsets+Extensions.swift
@@ -6,24 +6,29 @@ import SwiftUI
 
 extension EdgeInsets {
 
+    @inlinable
     public var horizontal: CGFloat {
         leading + trailing
     }
 
+    @inlinable
     public var vertical: CGFloat {
         top + bottom
     }
 
     public static let zero = EdgeInsets()
 
+    @inlinable
     public static func horizontal(_ inset: CGFloat) -> EdgeInsets {
         EdgeInsets(top: 0, leading: inset, bottom: 0, trailing: inset)
     }
 
+    @inlinable
     public static func vertical(_ inset: CGFloat) -> EdgeInsets {
         EdgeInsets(top: inset, leading: 0, bottom: inset, trailing: 0)
     }
 
+    @inlinable
     public static func uniform(_ inset: CGFloat) -> EdgeInsets {
         EdgeInsets(top: inset, leading: inset, bottom: inset, trailing: inset)
     }

--- a/Sources/Engine/Sources/GraphValue+Extensions.swift
+++ b/Sources/Engine/Sources/GraphValue+Extensions.swift
@@ -2,27 +2,46 @@
 // Copyright (c) Nathan Tannar
 //
 
+import Darwin
 import SwiftUI
 
-@_silgen_name("$s7SwiftUI11_GraphValueV13unsafeBitCast2toACyqd__Gqd__m_tlF")
-@available(iOS 18.0, macOS 15.0, tvOS 18.0, watchOS 11.0, visionOS 2.0, *)
-func _GraphValueUnsafeBitCast<A, B>(_ self: _GraphValue<A>, to: B.Type) -> _GraphValue<B>
+private typealias GraphValueUnsafeBitCastFunction<A, B> =
+    @convention(thin) (_GraphValue<A>, B.Type) -> _GraphValue<B>
 
-@_silgen_name("$s7SwiftUI11_GraphValueV10unsafeCast2toACyqd__Gqd__m_tlF")
-@available(iOS 18.0, macOS 15.0, tvOS 18.0, watchOS 11.0, visionOS 2.0, *)
-func _GraphValueUnsafeCast<A, B>(_ self: _GraphValue<A>, to: B.Type) -> _GraphValue<B>
+private typealias GraphValueUnsafeCastFunction<A, B> =
+    @convention(thin) (_GraphValue<A>, B.Type) -> _GraphValue<B>
+
+private let graphValueUnsafeBitCastSymbol = dlsym(
+    UnsafeMutableRawPointer(bitPattern: -2),
+    "$s7SwiftUI11_GraphValueV13unsafeBitCast2toACyqd__Gqd__m_tlF"
+)
+
+private let graphValueUnsafeCastSymbol = dlsym(
+    UnsafeMutableRawPointer(bitPattern: -2),
+    "$s7SwiftUI11_GraphValueV10unsafeCast2toACyqd__Gqd__m_tlF"
+)
 
 extension _GraphValue {
 
     func unsafeCast<T>(to _: T.Type) -> _GraphValue<T> {
         if #available(iOS 18.0, macOS 15.0, tvOS 18.0, watchOS 11.0, visionOS 2.0, *) {
-            if MemoryLayout<Value>.size == MemoryLayout<T>.size {
-                return _GraphValueUnsafeBitCast(self, to: T.self)
-            } else {
-                return _GraphValueUnsafeCast(self, to: T.self)
+            if MemoryLayout<Value>.size == MemoryLayout<T>.size,
+                let symbol = graphValueUnsafeBitCastSymbol
+            {
+                let function = unsafeBitCast(
+                    symbol,
+                    to: GraphValueUnsafeBitCastFunction<Value, T>.self
+                )
+                return function(self, T.self)
+            } else if let symbol = graphValueUnsafeCastSymbol {
+                let function = unsafeBitCast(
+                    symbol,
+                    to: GraphValueUnsafeCastFunction<Value, T>.self
+                )
+                return function(self, T.self)
             }
-        } else {
-            return unsafeBitCast(self, to: _GraphValue<T>.self)
         }
+
+        return unsafeBitCast(self, to: _GraphValue<T>.self)
     }
 }

--- a/Sources/Engine/Sources/MultiViewVisitor.swift
+++ b/Sources/Engine/Sources/MultiViewVisitor.swift
@@ -14,6 +14,7 @@ public typealias MultiViewProtocolDescriptor = EngineCore.MultiViewProtocolDescr
 
 @frozen
 public struct MultiViewSubviewVisitor: MultiViewVisitor {
+
     @frozen
     public struct Subview: View, Identifiable {
         public nonisolated(unsafe) var id: Context.ID
@@ -47,6 +48,7 @@ public struct MultiViewSubviewVisitor: MultiViewVisitor {
 }
 
 extension MultiViewAdapter where Visitor == MultiViewSubviewVisitor {
+
     @inlinable
     public init(
         @ViewBuilder source: () -> Source,
@@ -79,6 +81,7 @@ public struct MultiViewIsEmptyVisitor: MultiViewVisitor {
 }
 
 extension MultiViewAdapter where Visitor == MultiViewIsEmptyVisitor {
+
     @inlinable
     public static func isEmptyVisitor(
         @ViewBuilder source: () -> Source,

--- a/Sources/Engine/Sources/OptionalAdapter.swift
+++ b/Sources/Engine/Sources/OptionalAdapter.swift
@@ -60,7 +60,7 @@ public struct OptionalAdapter<
     public init<Value>(
         _ value: Value?,
         @ViewBuilder content: (Value) -> Content,
-        @ViewBuilder placeholder: () -> Placeholder
+        @ViewBuilder placeholder: () -> Placeholder = { EmptyView() }
     ) {
         switch value {
         case .some(let value):
@@ -74,7 +74,7 @@ public struct OptionalAdapter<
     public init<Value>(
         _ value: Binding<Value?>,
         @ViewBuilder content: (Binding<Value>) -> Content,
-        @ViewBuilder placeholder: () -> Placeholder
+        @ViewBuilder placeholder: () -> Placeholder = { EmptyView() }
     ) {
         if let unwrapped = value.unwrap() {
             self.content = .init(content(unwrapped))
@@ -87,7 +87,7 @@ public struct OptionalAdapter<
     public init(
         _ flag: Bool,
         @ViewBuilder content: () -> Content,
-        @ViewBuilder placeholder: () -> Placeholder
+        @ViewBuilder placeholder: () -> Placeholder = { EmptyView() }
     ) {
         self.content = flag ? .init(content()) : .init(placeholder())
     }
@@ -97,56 +97,19 @@ public struct OptionalAdapter<
     }
 }
 
-extension OptionalAdapter where Placeholder == EmptyView {
-    @inlinable
-    public init<Value>(
-        _ value: Value?,
-        @ViewBuilder content: (Value) -> Content
-    ) {
-        self.init(value, content: content, placeholder: { EmptyView() })
-    }
-
-    @inlinable
-    public init<Value>(
-        _ value: Binding<Value?>,
-        @ViewBuilder content: (Binding<Value>) -> Content
-    ) {
-        self.init(value, content: content, placeholder: { EmptyView() })
-    }
-
-    @inlinable
-    public init(
-        _ flag: Bool,
-        @ViewBuilder content: () -> Content
-    ) {
-        self.init(flag, content: content, placeholder: { EmptyView() })
-    }
-}
-
 extension OptionalAdapter {
 
     @inlinable
     public init<each Value>(
         _ values: repeat (each Value)?,
         @ViewBuilder content: (repeat each Value) -> Content,
-        @ViewBuilder placeholder: () -> Placeholder
+        @ViewBuilder placeholder: () -> Placeholder = { EmptyView() }
     ) {
         if let unwrapped = unwrap(repeat each values) {
             self.content = .init(content(repeat each unwrapped))
         } else {
             self.content = .init(placeholder())
         }
-    }
-}
-
-extension OptionalAdapter where Placeholder == EmptyView {
-
-    @inlinable
-    public init<each Value>(
-        _ values: repeat (each Value)?,
-        @ViewBuilder content: (repeat each Value) -> Content
-    ) {
-        self.init(repeat each values, content: content, placeholder: { EmptyView() })
     }
 }
 

--- a/Sources/Engine/Sources/ProposedSize.swift
+++ b/Sources/Engine/Sources/ProposedSize.swift
@@ -4,15 +4,18 @@
 
 import SwiftUI
 
+@frozen
 public struct ProposedSize: Equatable, Sendable {
     public var width: CGFloat?
     public var height: CGFloat?
 
+    @inlinable
     public init(width: CGFloat?, height: CGFloat?) {
         self.width = width
         self.height = height
     }
 
+    @inlinable
     public init(size: CGSize) {
         self.width = size.width >= 0 ? size.width : nil
         self.height = size.height >= 0 ? size.height : nil
@@ -28,10 +31,12 @@ public struct ProposedSize: Equatable, Sendable {
     }
 
     @available(iOS 16.0, macOS 13.0, tvOS 16.0, watchOS 9.0, *)
+    @inlinable
     public init(_ proposedSize: ProposedViewSize) {
         self.init(width: proposedSize.width, height: proposedSize.height)
     }
 
+    @inlinable
     public func replacingUnspecifiedDimensions(by size: CGSize = CGSize(width: 10, height: 10)) -> CGSize {
         return CGSize(width: width ?? size.width, height: height ?? size.height)
     }

--- a/Sources/Engine/Sources/StaticCondition.swift
+++ b/Sources/Engine/Sources/StaticCondition.swift
@@ -12,9 +12,69 @@ public protocol StaticCondition {
     static var value: Bool { get }
 }
 
+@frozen
+public enum TrueStaticCondition: StaticCondition {
+    public static let value: Bool = true
+}
+
+@frozen
+public enum FalseStaticCondition: StaticCondition {
+    public static let value: Bool = false
+}
+
 /// A `StaticCondition` that compares types
+@frozen
 public enum IsEqual<LHS, RHS>: StaticCondition {
+    @inlinable
     public static var value: Bool {
         LHS.self == RHS.self
+    }
+}
+
+// MARK: - Previews
+
+struct StaticCondition_Previews: PreviewProvider {
+
+    struct Preview<Condition: StaticCondition>: View {
+
+        var content: String
+
+        init(enabled content: String) where Condition == TrueStaticCondition {
+            self.content = content
+        }
+
+        init(disabled content: String) where Condition == FalseStaticCondition {
+            self.content = content
+        }
+
+        var body: some View {
+            StaticConditionalContent(Condition.self) {
+                Text(content)
+                    .background(Color.green)
+            } otherwise: {
+                Text(content)
+                    .background(Color.red)
+            }
+        }
+    }
+
+    static var previews: some View {
+        VStack {
+            StaticConditionalContent(TrueStaticCondition.self) {
+                Text("Enabled")
+            } otherwise: {
+                Text("Disabled")
+            }
+
+            StaticConditionalContent(FalseStaticCondition.self) {
+                Text("Enabled")
+            } otherwise: {
+                Text("Disabled")
+            }
+
+            Preview(enabled: "On")
+
+            Preview(disabled: "Off")
+        }
     }
 }

--- a/Sources/Engine/Sources/StaticConditionalContent.swift
+++ b/Sources/Engine/Sources/StaticConditionalContent.swift
@@ -18,10 +18,19 @@ public struct StaticConditionalContent<
     @inlinable
     public init(
         _ : Condition.Type = Condition.self,
-        @ViewBuilder then: () -> TrueContent,
-        @ViewBuilder otherwise: () -> FalseContent
+        @ViewBuilder then: () -> TrueContent = { EmptyView() },
+        @ViewBuilder otherwise: () -> FalseContent = { EmptyView() }
     ) {
-        self.content = Condition.value ? .init(then()) : .init(otherwise())
+        self.init(Condition.self, then: then(), otherwise: otherwise())
+    }
+
+    @inlinable
+    public init(
+        _ : Condition.Type = Condition.self,
+        then: TrueContent = EmptyView(),
+        otherwise: FalseContent = EmptyView()
+    ) {
+        self.content = Condition.value ? .init(then) : .init(otherwise)
     }
 
     private nonisolated var trueContent: TrueContent {
@@ -67,15 +76,6 @@ public struct StaticConditionalContent<
         Condition.value
             ? TrueContent._viewListCount(inputs: inputs)
             : FalseContent._viewListCount(inputs: inputs)
-    }
-}
-
-extension StaticConditionalContent where FalseContent == EmptyView {
-    public init(
-        _ : Condition.Type = Condition.self,
-        @ViewBuilder then: () -> TrueContent
-    ) {
-        self.init(Condition.self, then: then, otherwise: { EmptyView() })
     }
 }
 

--- a/Sources/Engine/Sources/StaticConditionalModifier.swift
+++ b/Sources/Engine/Sources/StaticConditionalModifier.swift
@@ -25,10 +25,19 @@ public struct StaticConditionalModifier<
     @inlinable
     public init(
         _ : Condition.Type = Condition.self,
-        @ViewModifierBuilder then: () -> TrueModifier,
-        @ViewModifierBuilder otherwise: () -> FalseModifier
+        @ViewModifierBuilder then: () -> TrueModifier = { EmptyModifier() },
+        @ViewModifierBuilder otherwise: () -> FalseModifier = { EmptyModifier() }
     ) {
-        self.storage = Condition.value ? .trueModifier(then()) : .falseModifier(otherwise())
+        self.init(Condition.self, then: then(), otherwise: otherwise())
+    }
+
+    @inlinable
+    public init(
+        _ : Condition.Type = Condition.self,
+        then: TrueModifier = EmptyModifier(),
+        otherwise: FalseModifier = EmptyModifier()
+    ) {
+        self.storage = Condition.value ? .trueModifier(then) : .falseModifier(otherwise)
     }
 
     private nonisolated var trueModifier: TrueModifier {
@@ -77,15 +86,6 @@ public struct StaticConditionalModifier<
         Condition.value
             ? TrueModifier._viewListCount(inputs: inputs, body: body)
             : FalseModifier._viewListCount(inputs: inputs, body: body)
-    }
-}
-
-extension StaticConditionalModifier where Condition: StaticCondition, FalseModifier == EmptyModifier {
-    public init(
-        _ : Condition.Type = Condition.self,
-        @ViewModifierBuilder then: () -> TrueModifier
-    ) {
-        self.init(Condition.self, then: then, otherwise: { EmptyModifier() })
     }
 }
 

--- a/Sources/Engine/Sources/StyleInputCondition.swift
+++ b/Sources/Engine/Sources/StyleInputCondition.swift
@@ -5,6 +5,7 @@
 import SwiftUI
 
 /// Evaluates ``ViewInputs`` for the existence of `Style`
+@frozen
 public struct StyleInputCondition<Style>: ViewInputsCondition {
 
     public static func evaluate(_ inputs: ViewInputs) -> Bool {

--- a/Sources/Engine/Sources/Transition+Extensions.swift
+++ b/Sources/Engine/Sources/Transition+Extensions.swift
@@ -16,6 +16,16 @@ extension Transition {
     }
 }
 
+@available(iOS 17.0, macOS 14.0, tvOS 17.0, watchOS 10.0, *)
+extension TransitionPhase {
+
+    /// The progress of the transition from the identity
+    @inlinable
+    public var progress: CGFloat {
+        isIdentity ? 1 : 0
+    }
+}
+
 
 @available(iOS 17.0, macOS 14.0, tvOS 17.0, watchOS 10.0, *)
 extension View {

--- a/Sources/Engine/Sources/UnitPoint+Extensions.swift
+++ b/Sources/Engine/Sources/UnitPoint+Extensions.swift
@@ -6,10 +6,12 @@ import SwiftUI
 
 extension UnitPoint {
 
+    @inlinable
     public func point(in size: CGSize, offset: CGPoint = .zero) -> CGPoint {
         CGPoint(x: offset.x + x * size.width, y: offset.y + y * size.height)
     }
 
+    @inlinable
     public func point(in rect: CGRect) -> CGPoint {
         point(in: rect.size, offset: rect.origin)
     }

--- a/Sources/Engine/Sources/VariadicViewSubviewModifier.swift
+++ b/Sources/Engine/Sources/VariadicViewSubviewModifier.swift
@@ -43,11 +43,10 @@ extension VariadicView {
     >(
         _ modifier: Modifier
     ) -> some View {
-        let id: KeyPath<VariadicView.Subview, Modifier.ID> = .selection(Modifier.ID.self)
-        return ForEachSubview(self, id: id) { index, subview in
+        ForEachSubview(self, id: .selection(Modifier.ID.self)) { index, subview in
             VariadicViewModifiedSubview(
                 content: VariadicViewSubviewModifierContent(
-                    id: subview[keyPath: id],
+                    id: subview[keyPath: KeyPath<VariadicView.Subview, Modifier.ID>.selection(Modifier.ID.self)],
                     index: index,
                     subview: subview
                 ),

--- a/Sources/Engine/Sources/ViewAlias.swift
+++ b/Sources/Engine/Sources/ViewAlias.swift
@@ -253,6 +253,18 @@ struct ViewAlias_Previews: PreviewProvider {
         }
     }
 
+    struct CustomView: View {
+        @State var value = 0
+
+        var body: some View {
+            Button {
+                value += 1
+            } label: {
+                Text("CustomView \(value)")
+            }
+        }
+    }
+
     static var previews: some View {
         ZStack {
             VStack {
@@ -262,28 +274,52 @@ struct ViewAlias_Previews: PreviewProvider {
                     .viewAlias(PreviewAlias.self) {
                         PreviewAlias()
                     }
-            }
-        }
-        .previewDisplayName("DefaultBody")
-
-        ZStack {
-            VStack {
-                VStack {
-                    PreviewAlias()
-
-                    PreviewAlias()
-                }
-                .viewAlias(PreviewAlias.self) {
-                    Text("Hello, World")
-                }
 
                 PreviewAlias()
                     .viewAlias(PreviewAlias.self) {
                         Text("Hello, World")
                     }
+
+                PreviewAlias()
+                    .viewAlias(PreviewAlias.self) {
+                        PreviewAlias()
+                            .viewAlias(PreviewAlias.self) {
+                                Text("Hello, World")
+                            }
+                    }
+
+                PreviewAlias()
+                    .viewAlias(PreviewAlias.self) {
+                        Text("Line 1")
+                    }
+                    .viewAlias(PreviewAlias.self) {
+                        Text("Line 2")
+                    }
+
+                PreviewAlias()
+                    .viewAlias(PreviewAlias.self) {
+                        PreviewAlias()
+                    }
+                    .viewAlias(PreviewAlias.self) {
+                        Text("Line 2")
+                    }
+
+                PreviewAlias()
+                    .viewAlias(PreviewAlias.self) {
+                        CustomView()
+                    }
+
+                HStack {
+                    PreviewAlias()
+
+                    PreviewAlias()
+                }
+                .viewAlias(PreviewAlias.self) {
+                    CustomView()
+                }
             }
         }
-        .previewDisplayName("Text")
+        .previewDisplayName("ViewAlias")
 
         ZStack {
             VStack {

--- a/Sources/Engine/Sources/ViewInputConditionalContent.swift
+++ b/Sources/Engine/Sources/ViewInputConditionalContent.swift
@@ -21,21 +21,20 @@ public struct ViewInputConditionalContent<
     @inlinable
     public init(
         _ : Condition.Type = Condition.self,
-        @ViewBuilder then: () -> TrueContent,
-        @ViewBuilder otherwise: () -> FalseContent
+        @ViewBuilder then: () -> TrueContent = { EmptyView() },
+        @ViewBuilder otherwise: () -> FalseContent = { EmptyView() }
     ) {
-        self.trueContent = then()
-        self.falseContent = otherwise()
+        self.init(Condition.self, then: then(), otherwise: otherwise())
     }
 
     @inlinable
     public init(
-        _ : Condition,
-        @ViewBuilder then: () -> TrueContent,
-        @ViewBuilder otherwise: () -> FalseContent
+        _ : Condition.Type = Condition.self,
+        then: TrueContent = EmptyView(),
+        otherwise: FalseContent = EmptyView()
     ) {
-        self.trueContent = then()
-        self.falseContent = otherwise()
+        self.trueContent = then
+        self.falseContent = otherwise
     }
 
     public static func makeView(
@@ -63,22 +62,6 @@ public struct ViewInputConditionalContent<
         Condition.evaluate(ViewInputs(inputs: inputs))
             ? TrueContent._viewListCount(inputs: inputs)
             : FalseContent._viewListCount(inputs: inputs)
-    }
-}
-
-extension ViewInputConditionalContent where FalseContent == EmptyView {
-    public init(
-        _ : Condition.Type = Condition.self,
-        @ViewBuilder then: () -> TrueContent
-    ) {
-        self.init(Condition.self, then: then, otherwise: { EmptyView() })
-    }
-
-    public init(
-        _ : Condition,
-        @ViewBuilder then: () -> TrueContent
-    ) {
-        self.init(Condition.self, then: then, otherwise: { EmptyView() })
     }
 }
 

--- a/Sources/Engine/Sources/ViewInputConditionalModifier.swift
+++ b/Sources/Engine/Sources/ViewInputConditionalModifier.swift
@@ -21,21 +21,20 @@ public struct ViewInputConditionalModifier<
     @inlinable
     public init(
         _ : Condition.Type = Condition.self,
-        @ViewModifierBuilder then: () -> TrueModifier,
-        @ViewModifierBuilder otherwise: () -> FalseModifier
+        @ViewModifierBuilder then: () -> TrueModifier = { EmptyModifier() },
+        @ViewModifierBuilder otherwise: () -> FalseModifier = { EmptyModifier() }
     ) {
-        self.trueModifier = then()
-        self.falseModifier = otherwise()
+        self.init(Condition.self, then: then(), otherwise: otherwise())
     }
 
     @inlinable
     public init(
-        _ : Condition,
-        @ViewModifierBuilder then: () -> TrueModifier,
-        @ViewModifierBuilder otherwise: () -> FalseModifier
+        _ : Condition.Type = Condition.self,
+        then: TrueModifier,
+        otherwise: FalseModifier
     ) {
-        self.trueModifier = then()
-        self.falseModifier = otherwise()
+        self.trueModifier = then
+        self.falseModifier = otherwise
     }
 
     public nonisolated static func makeView(
@@ -66,22 +65,6 @@ public struct ViewInputConditionalModifier<
         Condition.evaluate(ViewInputs(inputs: inputs))
             ? TrueModifier._viewListCount(inputs: inputs, body: body)
             : FalseModifier._viewListCount(inputs: inputs, body: body)
-    }
-}
-
-extension ViewInputConditionalModifier where FalseModifier == EmptyModifier {
-    public init(
-        _ : Condition.Type = Condition.self,
-        @ViewModifierBuilder then: () -> TrueModifier
-    ) {
-        self.init(Condition.self, then: then, otherwise: { EmptyModifier() })
-    }
-
-    public init(
-        _ : Condition,
-        @ViewModifierBuilder then: () -> TrueModifier
-    ) {
-        self.init(Condition.self, then: then, otherwise: { EmptyModifier() })
     }
 }
 

--- a/Sources/Engine/Sources/ViewStackAxisReader.swift
+++ b/Sources/Engine/Sources/ViewStackAxisReader.swift
@@ -27,10 +27,11 @@ public struct ViewStackAxisReader<
     @inlinable
     public init(
         @ViewBuilder content: (Axis) -> VerticalContent
-    ) where HorizontalContent == VerticalContent, OtherContent == EmptyView {
-        self.vertical = content(.vertical)
+    ) where HorizontalContent == VerticalContent, OtherContent == VerticalContent {
+        let vertical = content(.vertical)
+        self.vertical = vertical
         self.horizontal = content(.horizontal)
-        self.other = EmptyView()
+        self.other = vertical
     }
 
     @inlinable
@@ -42,6 +43,17 @@ public struct ViewStackAxisReader<
         self.vertical = vertical()
         self.horizontal = horizontal()
         self.other = other()
+    }
+
+    @inlinable
+    public init(
+        @ViewBuilder vertical: () -> VerticalContent,
+        @ViewBuilder horizontal: () -> HorizontalContent
+    ) where OtherContent == VerticalContent {
+        let vertical = vertical()
+        self.vertical = vertical
+        self.horizontal = horizontal()
+        self.other = vertical
     }
 
     public var body: some View {

--- a/Sources/Engine/Sources/ViewStyle.swift
+++ b/Sources/Engine/Sources/ViewStyle.swift
@@ -590,7 +590,7 @@ struct PreviewCustomView<Content: View>: View {
     }
 
     init(
-        configuration: PreviewCustomViewStyleConfiguration
+        _ configuration: PreviewCustomViewStyleConfiguration
     ) where Content == PreviewCustomViewStyleConfiguration.Content {
         self.content = configuration.content
     }
@@ -609,8 +609,10 @@ struct PreviewCustomViewBody: ViewStyledView {
     var configuration: PreviewCustomViewStyleConfiguration
 
     var body: some View {
-        PreviewCustomView(configuration: configuration)
+        PreviewCustomView(configuration)
+            .padding(4)
             .background(Color.yellow.opacity(0.25))
+            .border(Color.black.opacity(0.3))
     }
 
     static var defaultStyle: DefaultPreviewCustomViewStyle { .init() }
@@ -638,8 +640,8 @@ struct BorderedPreviewCustomViewStyle: PreviewCustomViewStyle {
     @Environment(\.borderColor) var borderColor
 
     func makeBody(configuration: PreviewCustomViewStyleConfiguration) -> some View {
-        PreviewCustomView(configuration: configuration)
-            .padding()
+        PreviewCustomView(configuration)
+            .padding(4)
             .border(borderColor)
     }
 }
@@ -662,30 +664,18 @@ struct ConditionalPreviewCustomViewStyle: PreviewCustomViewStyle {
 }
 
 struct PrimitiveBorderedPreviewCustomViewStyle: PreviewCustomViewStyle {
+
     func makeBody(configuration: PreviewCustomViewStyleConfiguration) -> some View {
         configuration.content
-            .modifier(Modifier())
-    }
-
-    struct Modifier: ViewModifier {
-        func body(content: Content) -> some View {
-            content
-                .border(Color.red)
-        }
+            .border(Color.red)
     }
 }
 
 struct PrimitiveMultiBorderedPreviewCustomViewStyle: PreviewCustomViewStyle {
+
     func makeBody(configuration: PreviewCustomViewStyleConfiguration) -> some View {
         HStack {
             configuration.content
-                .modifier(Modifier())
-        }
-    }
-
-    struct Modifier: ViewModifier {
-        func body(content: Content) -> some View {
-            content
                 .border(Color.red)
         }
     }

--- a/Sources/EngineCore/EnvironmentKeyVisitor.swift
+++ b/Sources/EngineCore/EnvironmentKeyVisitor.swift
@@ -34,7 +34,8 @@ extension ProtocolConformance where P == EnvironmentKeyProtocolDescriptor {
 }
 
 /// The ``TypeDescriptor`` for the `EnvironmentKey` protocol
-public struct EnvironmentKeyProtocolDescriptor: TypeDescriptor {
+@frozen
+public struct EnvironmentKeyProtocolDescriptor: TypeDescriptor, Sendable {
     public static var descriptor: UnsafeRawPointer {
         _EnvironmentKeyProtocolDescriptor()
     }

--- a/Sources/EngineCore/ProtocolConformance.swift
+++ b/Sources/EngineCore/ProtocolConformance.swift
@@ -7,6 +7,7 @@
 /// See also:
 ///  - `https://forums.swift.org/t/calling-swift-runtime-methods/23325`
 ///  - `https://github.com/apple/swift/blob/main/stdlib/toolchain/Compatibility50/ProtocolConformance.cpp`
+@frozen
 public struct ProtocolConformance<P: TypeDescriptor>: @unchecked Sendable {
     public var metadata: UnsafeRawPointer
     public var conformance: UnsafeRawPointer

--- a/Sources/EngineCore/ViewModifierVisitor.swift
+++ b/Sources/EngineCore/ViewModifierVisitor.swift
@@ -34,7 +34,8 @@ extension ProtocolConformance where P == ViewModifierProtocolDescriptor {
 }
 
 /// The ``TypeDescriptor`` for the `ViewModifier` protocol
-public struct ViewModifierProtocolDescriptor: TypeDescriptor {
+@frozen
+public struct ViewModifierProtocolDescriptor: TypeDescriptor, Sendable {
     public static var descriptor: UnsafeRawPointer {
         _ViewModifierProtocolDescriptor()
     }

--- a/Sources/EngineCore/ViewTraitKeyVisitor.swift
+++ b/Sources/EngineCore/ViewTraitKeyVisitor.swift
@@ -34,7 +34,8 @@ extension ProtocolConformance where P == ViewTraitKeyProtocolDescriptor {
 }
 
 /// The ``TypeDescriptor`` for the `_ViewTraitKey` protocol
-public struct ViewTraitKeyProtocolDescriptor: TypeDescriptor {
+@frozen
+public struct ViewTraitKeyProtocolDescriptor: TypeDescriptor, Sendable {
     public static var descriptor: UnsafeRawPointer {
         _ViewTraitKeyProtocolDescriptor()
     }

--- a/Sources/EngineCore/ViewVisitor.swift
+++ b/Sources/EngineCore/ViewVisitor.swift
@@ -87,7 +87,8 @@ extension ProtocolConformance where P: ViewProtocolConformanceDescriptor {
 public protocol ViewProtocolConformanceDescriptor: TypeDescriptor { }
 
 /// The ``TypeDescriptor`` for the `View` protocol
-public struct ViewProtocolDescriptor: ViewProtocolConformanceDescriptor {
+@frozen
+public struct ViewProtocolDescriptor: ViewProtocolConformanceDescriptor, Sendable {
     public static var descriptor: UnsafeRawPointer {
         _ViewProtocolDescriptor()
     }
@@ -111,7 +112,8 @@ public func _swift_visit_View<Content: View>(
 #if os(iOS) || os(tvOS) || os(visionOS)
 
 /// The ``TypeDescriptor`` for the `UIViewRepresentable` protocol
-public struct UIViewRepresentableProtocolDescriptor: ViewProtocolConformanceDescriptor {
+@frozen
+public struct UIViewRepresentableProtocolDescriptor: ViewProtocolConformanceDescriptor, Sendable {
     public static var descriptor: UnsafeRawPointer {
         _UIViewRepresentableProtocolDescriptor()
     }
@@ -133,7 +135,8 @@ public func _swift_visit_UIViewRepresentable<Content: UIViewRepresentable>(
 }
 
 /// The ``TypeDescriptor`` for the `UIViewControllerRepresentable` protocol
-public struct UIViewControllerRepresentableProtocolDescriptor: ViewProtocolConformanceDescriptor {
+@frozen
+public struct UIViewControllerRepresentableProtocolDescriptor: ViewProtocolConformanceDescriptor, Sendable {
     public static var descriptor: UnsafeRawPointer {
         _UIViewControllerRepresentableProtocolDescriptor()
     }
@@ -159,7 +162,8 @@ public func _swift_visit_UIViewControllerRepresentable<Content: UIViewController
 #if os(macOS)
 
 /// The ``TypeDescriptor`` for the `NSViewRepresentable` protocol
-public struct NSViewRepresentableProtocolDescriptor: ViewProtocolConformanceDescriptor {
+@frozen
+public struct NSViewRepresentableProtocolDescriptor: ViewProtocolConformanceDescriptor, Sendable {
     public static var descriptor: UnsafeRawPointer {
         _NSViewRepresentableProtocolDescriptor()
     }
@@ -181,7 +185,8 @@ public func _swift_visit_NSViewRepresentable<Content: NSViewRepresentable>(
 }
 
 /// The ``TypeDescriptor`` for the `NSViewControllerRepresentable` protocol
-public struct NSViewControllerRepresentableProtocolDescriptor: ViewProtocolConformanceDescriptor {
+@frozen
+public struct NSViewControllerRepresentableProtocolDescriptor: ViewProtocolConformanceDescriptor, Sendable {
     public static var descriptor: UnsafeRawPointer {
         _NSViewControllerRepresentableProtocolDescriptor()
     }

--- a/Sources/EngineMacros/StyledView.swift
+++ b/Sources/EngineMacros/StyledView.swift
@@ -91,16 +91,32 @@ import Engine
 ///         }
 ///     }
 ///
-@attached(peer, names: suffixed(Configuration), suffixed(Body), suffixed(Style), suffixed(StyleModifier), suffixed(DefaultStyle))
-@attached(member, names: named(_body), named(init))
+@attached(peer, names: suffixed(Configuration), suffixed(Body), suffixed(Style), prefixed(Styled), suffixed(StyleModifier), suffixed(DefaultStyle))
+@attached(member, names: named(_body), named(init), named(Configuration))
 public macro StyledView() = #externalMacro(module: "EngineMacrosCore", type: "StyledViewMacro")
 
 /// A protocol intended to be used with the ``@StyledView`` macro define a
 /// ``ViewStyle`` and all it's related components.
 @MainActor @preconcurrency
-public protocol StyledView: PrimitiveView {
+public protocol StyledView: PrimitiveView where Body == Never {
+
+    associatedtype Configuration
+
+    associatedtype ResolvedStyleBody: View = Never
+    @ViewBuilder @MainActor @preconcurrency static func makeResolvedStyleBody(configuration: Configuration) -> ResolvedStyleBody
+
+    associatedtype DefaultStyleBody: View
+    @ViewBuilder @MainActor @preconcurrency static func makeDefaultStyleBody(configuration: Configuration) -> DefaultStyleBody
+
     associatedtype _Body: View
     @ViewBuilder @MainActor @preconcurrency var _body: _Body { get }
+}
+
+extension StyledView where ResolvedStyleBody == Never {
+
+    public static func makeResolvedStyleBody(configuration: Configuration) -> Never {
+        fatalError("makeResolvedStyleBody() should not be called on \(String(describing: Self.self))")
+    }
 }
 
 extension StyledView {
@@ -143,14 +159,14 @@ private struct StyledViewBody<Content: StyledView>: View {
 public struct _DefaultStyledView<Content: StyledView>: View {
 
     @usableFromInline
-    var content: Content
+    var configuration: Content.Configuration
 
     @inlinable
-    public init(_ content: Content) {
-        self.content = content
+    public init(_ configuration: Content.Configuration) {
+        self.configuration = configuration
     }
 
     public var body: some View {
-        content.body
+        Content.makeDefaultStyleBody(configuration: configuration)
     }
 }

--- a/Sources/EngineMacrosCore/StyledViewMacro.swift
+++ b/Sources/EngineMacrosCore/StyledViewMacro.swift
@@ -45,37 +45,64 @@ public struct StyledViewMacro: PeerMacro, MemberMacro {
             members: members,
             generics: generics
         )
+        let subviewsHash = Set(subviews)
         let properties = getProperties(
             members: members
         )
-        return [
+        var declarations = [DeclSyntax]()
+        declarations.append(
             DeclSyntax(
                 stringLiteral: makeBody(
                     name: name,
                     prefix: prefix,
-                    subviews: subviews,
+                    subviews: subviewsHash,
                     properties: properties
                 )
-            ),
+            )
+        )
+        declarations.append(
             DeclSyntax(
                 stringLiteral: makeInit(
                     name: name,
                     prefix: prefix,
-                    subviews: subviews,
+                    subviews: subviewsHash,
                     properties: properties
                 )
-            ),
+            )
+        )
+        if !subviews.isEmpty {
+            declarations.append(
+                DeclSyntax(
+                    stringLiteral: makeInit(
+                        name: name,
+                        prefix: prefix,
+                        subviews: [],
+                        properties: properties
+                    )
+                )
+            )
+        }
+        declarations.append(
             DeclSyntax(
                 stringLiteral: makeConfigurationInit(
                     name: name,
                     prefix: prefix,
-                    subviews: subviews,
+                    subviews: subviewsHash,
                     properties: properties
                 )
             )
-        ]
+        )
+        declarations.append(
+            DeclSyntax(
+                stringLiteral: makeConfigurationTypealias(
+                    name: name,
+                    prefix: prefix
+                )
+            )
+        )
+        return declarations
     }
-    
+
     public static func expansion(
         of node: AttributeSyntax,
         providingPeersOf declaration: some DeclSyntaxProtocol,
@@ -96,15 +123,23 @@ public struct StyledViewMacro: PeerMacro, MemberMacro {
             members: members,
             generics: generics
         )
+        let subviewsHash = Set(subviews)
         let properties = getProperties(
             members: members
         )
-        return [
+        let declarations = [
+            DeclSyntax(
+                stringLiteral: makeStyledTypealias(
+                    name: name,
+                    prefix: prefix,
+                    subviews: subviews
+                )
+            ),
             DeclSyntax(
                 stringLiteral: makeConfigurationStruct(
                     name: name,
                     prefix: prefix,
-                    subviews: subviews,
+                    subviews: subviewsHash,
                     properties: properties
                 )
             ),
@@ -132,6 +167,7 @@ public struct StyledViewMacro: PeerMacro, MemberMacro {
                 )
             )
         ]
+        return declarations
     }
 
     private static func getType(
@@ -173,7 +209,7 @@ public struct StyledViewMacro: PeerMacro, MemberMacro {
     private static func getSubviews(
         members: MemberBlockItemListSyntax,
         generics: GenericParameterClauseSyntax?
-    ) -> Set<String> {
+    ) -> [String] {
         guard let generics else {
             return []
         }
@@ -183,7 +219,7 @@ public struct StyledViewMacro: PeerMacro, MemberMacro {
             }
             return type.as(IdentifierTypeSyntax.self)?.name.text == "View"
         }
-        return Set(views.map { $0.name.text })
+        return views.map { $0.name.text }
     }
 
     private struct Property {
@@ -194,7 +230,7 @@ public struct StyledViewMacro: PeerMacro, MemberMacro {
         members: MemberBlockItemListSyntax
     ) -> [Property] {
         members.compactMap { member -> Property? in
-            guard 
+            guard
                 let variable = member.decl.as(VariableDeclSyntax.self),
                 variable.bindings.count == 1,
                 let binding = variable.bindings.first,
@@ -208,6 +244,24 @@ public struct StyledViewMacro: PeerMacro, MemberMacro {
                 field: field
             )
         }
+    }
+
+    private static func hasBody(
+        members: MemberBlockItemListSyntax
+    ) -> Bool {
+        for member in members {
+            guard
+                let variable = member.decl.as(VariableDeclSyntax.self),
+                variable.bindings.count == 1,
+                let binding = variable.bindings.first,
+                let identifier = binding.pattern.as(IdentifierPatternSyntax.self),
+                identifier.identifier.text == "body"
+            else {
+                continue
+            }
+            return true
+        }
+        return false
     }
 
     private static func makeInit(
@@ -288,6 +342,16 @@ public struct StyledViewMacro: PeerMacro, MemberMacro {
             }
             return ".viewAlias(\(name)Configuration.\(property.field.type).self) { \(property.name) }"
         }
+        if params.isEmpty {
+            return """
+            \(prefix)var _body: some View {
+                \(name)Body(
+                    configuration: \(name)Configuration()
+                )
+                \(modifiers.joined(separator: "\n"))
+            }
+            """
+        }
         return """
         \(prefix)var _body: some View {
             \(name)Body(
@@ -326,6 +390,32 @@ public struct StyledViewMacro: PeerMacro, MemberMacro {
         """
     }
 
+    private static func makeConfigurationTypealias(
+        name: String,
+        prefix: String
+    ) -> String {
+        return """
+        \(prefix)typealias Configuration = \(name)Configuration
+        """
+    }
+
+    private static func makeStyledTypealias(
+        name: String,
+        prefix: String,
+        subviews: [String],
+    ) -> String {
+        if subviews.isEmpty {
+            return """
+            \(prefix)typealias Styled\(name) = \(name)
+            """
+        }
+        let configuration = "\(name)Configuration"
+        let subviews = subviews.map { "\(configuration).\($0)"}
+        return """
+        \(prefix)typealias Styled\(name) = \(name)<\(subviews.joined(separator: ", "))>
+        """
+    }
+
     private static func makeStyleProtocol(
         name: String,
         prefix: String
@@ -343,7 +433,7 @@ public struct StyledViewMacro: PeerMacro, MemberMacro {
         return """
         \(prefix)struct \(name)DefaultStyle: \(name)Style {
             \(prefix)func makeBody(configuration: \(name)Configuration) -> some View {
-                _DefaultStyledView(\(name)(configuration))
+                _DefaultStyledView<Styled\(name)>(configuration)
             }
         }
         """
@@ -355,6 +445,10 @@ public struct StyledViewMacro: PeerMacro, MemberMacro {
         return """
         private struct \(name)Body: ViewStyledView {
             var configuration: \(name)Configuration
+
+            var body: some View {
+                Styled\(name).makeResolvedStyleBody(configuration: configuration)
+            }
 
             static var defaultStyle: \(name)DefaultStyle {
                 \(name)DefaultStyle()

--- a/Sources/EngineTests/EngineMacroTests.swift
+++ b/Sources/EngineTests/EngineMacroTests.swift
@@ -23,10 +23,10 @@ final class MacroTests: XCTestCase {
             @Binding var isEnabled: Bool
             var selection: Binding<Int>?
 
-            var body: some View {
+            static func makeDefaultStyleBody(configuration: LabelViewConfiguration) -> some View {
                 HStack {
-                    label
-                    content
+                    configuration.label
+                    configuration.content
                 }
                 .id(identifier)
             }
@@ -44,10 +44,10 @@ final class MacroTests: XCTestCase {
             @Binding var isEnabled: Bool
             var selection: Binding<Int>?
 
-            var body: some View {
+            static func makeDefaultStyleBody(configuration: LabelViewConfiguration) -> some View {
                 HStack {
-                    label
-                    content
+                    configuration.label
+                    configuration.content
                 }
                 .id(identifier)
             }
@@ -95,6 +95,28 @@ final class MacroTests: XCTestCase {
             }
 
             init(
+                label: Label,
+                content: Content,
+                identifier: String,
+                value: String? = nil,
+                traits: Array<Int>,
+                isEnabled: Binding<Bool>,
+                selection: Binding<Int>? = nil,
+                action: @escaping () -> Void,
+                completion: ((Bool) -> Void)? = nil
+            ) {
+                self.label = label
+                self.content = content
+                self.identifier = identifier
+                self.value = value
+                self.traits = traits
+                self.action = action
+                self.completion = completion
+                self._isEnabled = isEnabled
+                self.selection = selection
+            }
+
+            init(
                 _ configuration: LabelViewConfiguration
             ) where Label == LabelViewConfiguration.Label, Content == LabelViewConfiguration.Content {
                 self.label = configuration.label
@@ -107,7 +129,11 @@ final class MacroTests: XCTestCase {
                 self._isEnabled = configuration.$isEnabled
                 self.selection = configuration.selection
             }
+        
+            typealias Configuration = LabelViewConfiguration
         }
+        
+        typealias StyledLabelView = LabelView<LabelViewConfiguration.Label, LabelViewConfiguration.Content>
 
         struct LabelViewConfiguration {
             struct Label: ViewAlias {
@@ -134,12 +160,16 @@ final class MacroTests: XCTestCase {
 
         struct LabelViewDefaultStyle: LabelViewStyle {
             func makeBody(configuration: LabelViewConfiguration) -> some View {
-                _DefaultStyledView(LabelView(configuration))
+                _DefaultStyledView<StyledLabelView>(configuration)
             }
         }
 
         private struct LabelViewBody: ViewStyledView {
             var configuration: LabelViewConfiguration
+
+            var body: some View {
+                StyledLabelView.makeResolvedStyleBody(configuration: configuration)
+            }
 
             static var defaultStyle: LabelViewDefaultStyle {
                 LabelViewDefaultStyle()
@@ -155,6 +185,121 @@ final class MacroTests: XCTestCase {
 
             func body(content: Content) -> some View {
                 content.styledViewStyle(LabelViewBody.self, style: style)
+            }
+        }
+        """
+        assertMacroExpansion(
+            sourceInput,
+            expandedSource: sourceOutput,
+            macros: [
+                "StyledView": StyledViewMacro.self,
+            ]
+        )
+    }
+
+    func testResolvedBodyStyledViewMacro() throws {
+        let sourceInput = """
+        @StyledView
+        struct ContainerView<Content: View>: StyledView {
+            var content: Content
+        
+            static func makeResolvedStyleBody(configuration: ContainerViewConfiguration) -> some View {
+                StyledContainerView {
+                    configuration.content
+                        .padding()
+                }
+            }
+
+            static func makeDefaultStyleBody(configuration: ContainerViewConfiguration) -> some View {
+                configuration.content
+            }
+        }
+        """
+        let sourceOutput = """
+        struct ContainerView<Content: View>: StyledView {
+            var content: Content
+
+            static func makeResolvedStyleBody(configuration: ContainerViewConfiguration) -> some View {
+                StyledContainerView {
+                    configuration.content
+                        .padding()
+                }
+            }
+
+            static func makeDefaultStyleBody(configuration: ContainerViewConfiguration) -> some View {
+                configuration.content
+            }
+
+            var _body: some View {
+                ContainerViewBody(
+                    configuration: ContainerViewConfiguration()
+                )
+                .viewAlias(ContainerViewConfiguration.Content.self) {
+                    content
+                }
+            }
+
+            init(
+                @ViewBuilder content: () -> Content
+            ) {
+                self.content = content()
+            }
+
+            init(
+                content: Content
+            ) {
+                self.content = content
+            }
+
+            init(
+                _ configuration: ContainerViewConfiguration
+            ) where Content == ContainerViewConfiguration.Content {
+                self.content = configuration.content
+            }
+        
+            typealias Configuration = ContainerViewConfiguration
+        }
+        
+        typealias StyledContainerView = ContainerView<ContainerViewConfiguration.Content>
+
+        struct ContainerViewConfiguration {
+            struct Content: ViewAlias {
+            }
+            var content: Content {
+                .init()
+            }
+        }
+
+        protocol ContainerViewStyle: ViewStyle where Configuration == ContainerViewConfiguration {
+        }
+
+        struct ContainerViewDefaultStyle: ContainerViewStyle {
+            func makeBody(configuration: ContainerViewConfiguration) -> some View {
+                _DefaultStyledView<StyledContainerView>(configuration)
+            }
+        }
+
+        private struct ContainerViewBody: ViewStyledView {
+            var configuration: ContainerViewConfiguration
+
+            var body: some View {
+                StyledContainerView.makeResolvedStyleBody(configuration: configuration)
+            }
+
+            static var defaultStyle: ContainerViewDefaultStyle {
+                ContainerViewDefaultStyle()
+            }
+        }
+
+        struct ContainerViewStyleModifier<Style: ContainerViewStyle>: ViewModifier {
+            var style: Style
+
+            init(_ style: Style) {
+                self.style = style
+            }
+
+            func body(content: Content) -> some View {
+                content.styledViewStyle(ContainerViewBody.self, style: style)
             }
         }
         """


### PR DESCRIPTION
The following are not resolvable on iOS 17:

```
(undefined) external _$s7SwiftUI11_GraphValueV10unsafeCast...
(undefined) external _$s7SwiftUI11_GraphValueV13unsafeBitCast...
```